### PR TITLE
fix: backend / keycloak docker dependency

### DIFF
--- a/backend/core/middleware.py
+++ b/backend/core/middleware.py
@@ -52,7 +52,7 @@ class KeycloakHelper(object):
         self.keycloak_authorization_config = self.config.get('KEYCLOAK_AUTHORIZATION_CONFIG', None)
 
         # Create Keycloak instance
-        self.keycloak = KeycloakOpenID(server_url=self.server_url,
+        self.keycloak = KeycloakOpenID(server_url=self.config['KEYCLOAK_INTERNAL_SERVER_URL'] + "/auth", # We use internal since nginx does not start unless the backend is UP
                                        client_id=self.client_id,
                                        realm_name=self.realm,
                                        client_secret_key=self.client_secret_key,

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -182,6 +182,7 @@ KEYCLOAK_CONFIG = {
     'KEYCLOAK_AUTHORIZATION_CONFIG': os.path.join(CONFIG_DIR , 'authorization-config.json'),
     'KEYCLOAK_METHOD_VALIDATE_TOKEN': 'DECODE',
     'KEYCLOAK_SERVER_URL': os.getenv("KEYCLOAK_SERVER_URL"),
+    'KEYCLOAK_INTERNAL_SERVER_URL': os.getenv("BASE_URL"), # @todo : rename env var BASE_URL
     'KEYCLOAK_CLIENT_SECRET_KEY': os.getenv("CLIENT_SECRET"),
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,6 +132,11 @@ services:
       - POSTGRES_PASSWORD=igad
       - POSTGRES_USER=igad
       - POSTGRES_DB=igad
+    healthcheck:
+      test: ["CMD-SHELL", "sh -c 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}'"]
+      interval: 10s
+      timeout: 3s
+      retries: 3
 
   backend:
     container_name: backend
@@ -140,8 +145,10 @@ services:
       context: ./backend
       dockerfile: Dockerfile
     depends_on:
-      - backend_db
-      - keycloak
+      backend_db:
+        condition: service_healthy
+      keycloak:
+        condition: service_healthy
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
Backend fails on start because it's sending a request to keycloak through the public URL. Since nginx starts only once the backend is UP, the container will fail to start. 