### PR TITLE
fix(keycloak): Add protocol to Airflow redirect URL

### DIFF
--- a/keycloak/realm/realm.json
+++ b/keycloak/realm/realm.json
@@ -915,7 +915,7 @@
       "alwaysDisplayInConsole": false,
       "clientAuthenticatorType": "client-secret",
       "secret": "${AIRFLOW_KEYCLOAK_CLIENT_SECRET}",
-      "redirectUris": ["${NGINX_AIRFLOW_DOMAIN_NAME}/*"],
+      "redirectUris": ["http://${NGINX_AIRFLOW_DOMAIN_NAME}/*", "https://${NGINX_AIRFLOW_DOMAIN_NAME}/*"],
       "webOrigins": [],
       "notBefore": 0,
       "bearerOnly": false,


### PR DESCRIPTION
Airflow is currently unable to complete the Keycloak login process as its redirect URL is not registered as legal in Keycloak. This is because the URL given in the realm.json file is missing the schema portion. Add both, the `http` and `https` variants to make sure the redirect succeeds.