### PR TITLE
fix airflow redirect url

### DIFF
--- a/nginx/package-conf-dev/airflow.conf.template
+++ b/nginx/package-conf-dev/airflow.conf.template
@@ -25,9 +25,9 @@ server {
 		proxy_set_header Host                    $host;
     	proxy_set_header X-Real-IP               $remote_addr;
     	proxy_set_header X-Scheme                $scheme;
-    	proxy_set_header X-Auth-Request-Redirect $request_uri;
-		proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
-		proxy_pass http://$NGINX_UPSTREAM_AIRFLOW:8080/;
+    	proxy_set_header X-Auth-Request-Redirect $request_uri/home;
+		proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri/home;
+		proxy_pass http://$NGINX_UPSTREAM_AIRFLOW:8080;
 		error_log /var/log/airflow_end_errors.log;
 	}
 }

--- a/nginx/package-conf-local/airflow.conf.template
+++ b/nginx/package-conf-local/airflow.conf.template
@@ -12,6 +12,7 @@ server {
 	}
 }
 
+
 server {
 	listen 443 ssl;
 	server_name $NGINX_AIRFLOW_DOMAIN_NAME;
@@ -21,13 +22,17 @@ server {
 	#include /etc/letsencrypt/options-ssl-nginx.conf;
 	#ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
+	# if ($cookie_session) {
+	# 	return 301 https://$host$request_uri/login;
+	# }
+
 	location / {
 		proxy_set_header Host                    $host;
     	proxy_set_header X-Real-IP               $remote_addr;
     	proxy_set_header X-Scheme                $scheme;
-    	proxy_set_header X-Auth-Request-Redirect $request_uri;
-		proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
-		proxy_pass http://$NGINX_UPSTREAM_AIRFLOW:8080/;
+    	proxy_set_header X-Auth-Request-Redirect $request_uri/home;
+		proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri/home;
+		proxy_pass http://$NGINX_UPSTREAM_AIRFLOW:8080;
 		error_log /var/log/airflow_end_errors.log;
 	}
 }


### PR DESCRIPTION
This pr fix the 502 error from keycloak
infact when you type airflow.igad.local for example airflow will have a **next**  http query which is the link that you redirect after keycloak
the issue is related to flask: infact when you open an API that has a protected/ authentication annotation it will redirect you to login page with a **next** http query that contains the protected link
I tried to fix this issue in airflow although i couldn't so I tried to fix it in nginx where I precise the redirect uri