### PR TITLE
Update/env var dev

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -55,7 +55,7 @@ BACKEND_PUBLIC_URL=https://home2.igad-health.eu
 BACKEND_REST_REDIRECT_URI=https://home2.igad-health.eu/users/create-password
 BACKEND_MINIO_URL=storage:9000
 BACKEND_MINIO_ACCESS_KEY=minio
-BACKEND_MINIO_SECRET_KEY=miniorepan
+BACKEND_MINIO_SECRET_KEY=RarelyHook431
 BACKEND_MINIO_BUCKET="repan-bucket"
 BACKEND_AVATAR_BASE_URL=https://cache2.igad-health.eu/avatars/
 BACKEND_MAIL_MAILER=smtp
@@ -82,7 +82,7 @@ BACKEND_CORS_ORIGIN_ALLOW_ALL=True
 BACKEND_SUPERSET_BASE_URL=http://superset:8088/api/v1
 BACKEND_SUPERSET_LOGIN=http://superset:8088/api/v1/security/login
 BACKEND_SUPERSET_USER=admin
-BACKEND_SUPERSET_PASS=admin
+BACKEND_SUPERSET_PASS=ImmenseWatch150
 BACKEND_SUPERSET_PROVIDER=db
 BACKEND_SUPERSET_ALLOWED_DOMAINS=https://home2.igad-health.eu
 
@@ -161,7 +161,7 @@ SUPERSET_KEYCLOAK_ADMIN_PASSWORD=WeaklyBDSMFreak203
 
 ### AIRFLOW ###
 AIRFLOW_POSTGRES_USER=airflow
-AIRFLOW_POSTGRES_PASSWORD=airflow
+AIRFLOW_POSTGRES_PASSWORD=PhysicallyArch363
 AIRFLOW_POSTGRES_DB=airflow
 
 AIRFLOW_AIRFLOW__CORE__FERNET_KEY=UKMzEm3yIuFYEq1y3-2FxPNWSVwRASpahmQ9kQfEr8E=
@@ -170,7 +170,7 @@ AIRFLOW_AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION=True
 AIRFLOW_AIRFLOW__CORE__LOAD_EXAMPLES=False
 AIRFLOW_SQLALCHEMY_SILENCE_UBER_WARNING=1
 AIRFLOW_AIRFLOW_UID=0
-AIRFLOW_AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:airflow@airflow-pg/airflow
+AIRFLOW_AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=postgresql+psycopg2://airflow:PhysicallyArch363@airflow-pg/airflow
 AIRFLOW_AIRFLOW__DATABASE__LOAD_DEFAULT_CONNECTIONS=False
 AIRFLOW__AIRFLOW_DB_UPGRADE=True
 AIRFLOW__AIRFLOW_WWW_USER_CREATE=True
@@ -188,7 +188,7 @@ AIRFLOW_AUTH_USER_REGISTRATION_ROLE=Public
 AIRFLOW_AUTH_ROLES_SYNC_AT_LOGIN=True
 AIRFLOW_ENVIRONMENT=/home/igad/Regional-Pandemic-Analytics
 
-AIRFLOW_CONN_HOP_DEFAULT='{"conn_type": "http","login": "admin","password": "admin","host": "hop-server","port": 8080,"schema": "","extra": {"hop_home": "/hop"}}'
+AIRFLOW_CONN_HOP_DEFAULT='{"conn_type": "http","login": "admin","password": "Teeny-tinyPosition195","host": "hop-server","port": 8080,"schema": "","extra": {"hop_home": "/hop"}}'
 AIRFLOW_HOP_PIPELINES=/hop/config/projects/default
 
 ### KEYCLOAK ###
@@ -208,7 +208,7 @@ KEYCLOAK_INTERNAL=http://keycloak:8080
 
 ### MINIO ###
 MINIO_ROOT_USER=minio
-MINIO_ROOT_PASSWORD=miniorepan
+MINIO_ROOT_PASSWORD=RarelyHook431
 MINIO_BROWSER_REDIRECT_URL=https://console.cache2.igad-health.eu
 MINIO_SERVER_URL=http://localhost:9000
 MINIO_MC_REMOTE_SERVER_URL=http://storage:9000
@@ -244,7 +244,7 @@ HOP_KEYCLOAK_SERVER_URL=https://auth2.igad-health.eu
 HOP_KEYCLOAK_SSL_REQUIRED=all
 HOP_KEYCLOAK_CONFIDENTIAL_PORT=443
 HOP_SERVER_USER=admin
-HOP_SERVER_PASS=admin
+HOP_SERVER_PASS=Teeny-tinyPosition195
 HOP_KEYCLOAK_DISABLE_SSL_VERIFICATION=false
 
 ### OPENHIM ###


### PR DESCRIPTION
There is 2 missing env var that I could not change 
the first one related to airflow www user which is stored in an SQL table and when passing the env var it s not updated 
I wanted to changed it from the airflow console, but there is no option to do so
I could not changed using sql as the passwords are encrypted

the second related to keycloak db where after changing the password I connected to the container to update the db user as usual but an error popped up: 
"must be superuser to alter replication roles or change replication attribute"

these 2 env var could be changed when we delete the volumes so maybe when deploying a new dev env