### PR TITLE
feat: support downloading pipelines from the UI

### DIFF
--- a/backend/pipeline/urls.py
+++ b/backend/pipeline/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
-from .views import PipelineListView, PipelineDetailView
+from .views import PipelineDownloadView, PipelineListView, PipelineDetailView
 
 urlpatterns = [
     path("", PipelineListView.as_view()),
     path("/list/", PipelineListView.as_view()),
     path("/list/<str:query>", PipelineListView.as_view()),
     path("/<str:name>", PipelineDetailView.as_view()),
+    path("/download/<str:name>", PipelineDownloadView.as_view()),
 ]

--- a/frontend/src/modules/pipeline/pipeline.ts
+++ b/frontend/src/modules/pipeline/pipeline.ts
@@ -15,6 +15,11 @@ export const pipelineApi = createApi({
     getPipeline: builder.query<PipelineData, string>({
       query: (name) => `/pipeline/${name}`,
     }),
+
+    downloadPipeline: builder.query<any, string>({
+      query: (name) => `/pipeline/download/${name}`,
+    }),
+
     templates: builder.query<TemplateList, string>({
       query: (query) => `/hop/${query}`,
     }),
@@ -41,6 +46,7 @@ export const pipelineApi = createApi({
 export const {
   useGetAllPipelinesQuery,
   useGetPipelineQuery,
+  useDownloadPipelineQuery,
   useTemplatesQuery,
   useCreatePipelineMutation,
   useUpdatePipelineMutation,


### PR DESCRIPTION
### Description:
New feature to support downloading user created pipelines from the UI.
This feature is important not only to backup complex pipelines but also to export and share them with other users

### Screenshot:
<img width="1264" alt="Bildschirmfoto 2024-01-01 um 21 37 26" src="https://github.com/Speedykom/Regional-Pandemic-Analytics/assets/95882599/5de238bb-6817-4e8f-9790-40766db62342">

### Testing:
1. Login and navigate to my pipelines section

2. Click on the download icon of one of the created pipelines.
3. The hop pipeline should be downloaded to the local machine's file system