### PR TITLE
fix: stop click event propagation to the process chain content

### DIFF
--- a/frontend/src/modules/process/components/Stepper.tsx
+++ b/frontend/src/modules/process/components/Stepper.tsx
@@ -50,7 +50,11 @@ export default function Stepper({
   ];
 
   return (
-    <div>
+    <div
+      onClick={(e) => {
+        e.stopPropagation(); // Prevent the event from reaching the Card component
+      }}
+    >
       <TabGroup>
         <TabList className="pl-40 pr-40 flex justify-around" color="green">
           {steps.map((step) => {


### PR DESCRIPTION
As a process chain (accordion) gets collapsed/expanded by mouse click, the click event should not be propagated to the content of the process chain to be able to do some interaction within the different tabs (steps) of a process chain. This is currently not the case