### PR TITLE
Fix: thumbnail PR merge issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ x-superset-common: &superset
     - SUPERSET_JWT_USER_MAPPING=${SUPERSET_JWT_USER_MAPPING}
   volumes:
     - ./superset/superset_config.py:/app/pythonpath/superset_config.py
-    - ./superset/import/dashboard_export_20240128.zip:/app/dashboard_export_20240128.zip
+    - ./superset/import/dashboard_export.zip:/app/dashboard_export.zip
   depends_on:
     - superset_db
     - superset_cache

--- a/keycloak/realm/realm.json
+++ b/keycloak/realm/realm.json
@@ -1307,7 +1307,7 @@
             "logic": "POSITIVE",
             "decisionStrategy": "UNANIMOUS",
             "config": {
-              "clients": "[\"airflow\",\"repan-staging\"]"
+              "clients": "[\"airflow\",\"${BACKEND_CLIENT_ID}\"]"
             }
           },
           {


### PR DESCRIPTION
After merging the Thumbnail PR there were issues observed only on the dev server

Realm initial loading didn't work as the client repan-staging was hard coded however on the dev and prod the client's name is frontend and not repan-staging


Dashboard backup/restore still reference an older backup as after merging main to the PR this undo my last changes on the backup version