### PR TITLE
feat(backend): Add gzip compression middleware to Django

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -59,7 +59,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "core.middleware.KeycloakMiddleware",
-    "core.user_id.UserIdMiddleware"
+    "core.user_id.UserIdMiddleware",
+    "django.middleware.gzip.GZipMiddleware"
 ]
 
 ROOT_URLCONF = "core.urls"


### PR DESCRIPTION
To reduce the number of bytes that need to go over the wire, add gzip compression to Django. The impact on the server of such a measure is usually minimal while it may make requests over slow connections significantly faster.