### PR TITLE
feat : Implement Responsive Design and Pagination on Superset Charts Page

### DIFF
--- a/frontend/src/modules/superset/views/ListChart.tsx
+++ b/frontend/src/modules/superset/views/ListChart.tsx
@@ -41,7 +41,7 @@ export const ChartList = () => {
       </nav>
       <input
         type="text"
-        placeholder={t('searchForCharts')}
+        placeholder="Search for charts..."
         className="w-full border border-gray-300 rounded-md p-2 mb-3"
         value={searchInput}
         onChange={(e) => setSearchInput(e.target.value)}


### PR DESCRIPTION
## Overview

This pull request addresses the issue of non-responsiveness on the Superset charts page. In addition to making the charts table responsive, a paginator has been introduced to enhance user experience by limiting the number of visible charts to 3 per page.

## Changes

- The `ChartList` component now uses `MediaQuery` and TailwindCSS classes to allow the table of charts to adjust for various screen sizes.
- Pagination logic has been implemented to navigate through the charts with the ability to view 5 items per page. This uses state hooks and conditional rendering based on the current page and total available charts.
- TypeScript annotations have been added to ensure type safety and to resolve any implicit 'any' type warnings.
- The UI of the pagination has been improved using TailwindCSS for a cleaner and more user-friendly interface.

In the following snapshots I have tested the pagination with 3 items per page : 
![22](https://github.com/Speedykom/Regional-Pandemic-Analytics/assets/158754867/139593cd-4a54-4425-a82e-505b9f4ce762)
