### PR TITLE
Fix: Remove next execution date for 'once' schedule interval

### DIFF
--- a/frontend/src/modules/process/components/StepperElements/Orchestration.tsx
+++ b/frontend/src/modules/process/components/StepperElements/Orchestration.tsx
@@ -23,6 +23,10 @@ export default function Orchestration({
   const lastParsedTimeDate = new Date(lastParsedTime);
   const nextDagRunDate = new Date(nextDagRun);
 
+  const isValidDate = (date: Date) => {
+    return date.getTime() !== new Date(0).getTime();
+  };
+
   return (
     <div className="flex flex-col space-y-3 ">
       <div className="flex justify-center">
@@ -37,12 +41,14 @@ export default function Orchestration({
               {lastParsedTimeDate.toUTCString()}
             </TableCell>
           </TableRow>
-          <TableRow>
-            <TableHeaderCell>Next scheduled execution</TableHeaderCell>
-            <TableCell className="whitespace-normal">
-              {nextDagRunDate.toUTCString()}
-            </TableCell>
-          </TableRow>
+          {isValidDate(nextDagRunDate) && (
+            <TableRow>
+              <TableHeaderCell>Next scheduled execution</TableHeaderCell>
+              <TableCell className="whitespace-normal">
+                {nextDagRunDate.toUTCString()}
+              </TableCell>
+            </TableRow>
+          )}
         </Table>
       </div>
       <div className="">


### PR DESCRIPTION
## Summary
This pull request removes the display of the next scheduled execution date from the Orchestration component when the schedule interval is set to 'once'.

## Changes
- Added a condition in the `Orchestration.tsx` to check if `nextDagRun` is a valid date before displaying it. This has ensured that the epoch date (January 1, 1970) is not displayed, which was the default behavior when no future runs are scheduled.

## Testing
- The "Next scheduled execution" field should now be hidden when the interval is set to 'once'.
- Other schedule intervals should display the next execution date as expected.

## Screenshots

![image](https://github.com/Speedykom/Regional-Pandemic-Analytics/assets/158754867/2541c986-f134-4a60-9b86-c236636f19e0)

![image](https://github.com/Speedykom/Regional-Pandemic-Analytics/assets/158754867/1230ed23-b1d6-499e-9013-6e7dfffa089e)

