### PR TITLE
fix : Newly created users can't login directly to the frontend 

### DIFF
--- a/keycloak/realm/realm.json
+++ b/keycloak/realm/realm.json
@@ -2662,8 +2662,8 @@
   "eventsEnabled": false,
   "eventsListeners": ["jboss-logging"],
   "enabledEventTypes": [],
-  "adminEventsEnabled": true,
-  "adminEventsDetailsEnabled": true,
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
   "identityProviders": [],
   "identityProviderMappers": [],
   "components": {


### PR DESCRIPTION
Jira Ticket: https://speedykom.atlassian.net/browse/REPAN-403

This PR fixes the issue where new users created in Keycloak cannot log in immediately to the frontend. The frontend was failing because Superset did not recognize the new user.

**Changes Made**
- Updated the load_user_jwt method in CustomSupersetSecurityManager.
- Now, if a user does not exist in Superset, it will be created using the JWT token data.


**Solution**
With these changes, new users can log in right after being created in Keycloak. Superset will create the user if they don't exist, preventing any errors and allowing the UI to show an empty dashboard.