### PR TITLE
Adding Software Composition Analysis to the workflow 

### DIFF
--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,66 @@
+name: SCA
+
+on:
+  schedule:
+    - cron: "0 0 1 * *"
+
+jobs:
+  frontend-integration:
+    runs-on: ubuntu-latest
+    name: Frontend Integration
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+          working-directory: frontend
+          cache-dependency-path: frontend/package-lock.json
+          cache: "npm"
+      - run: npm install
+        working-directory: frontend
+      - run: npm i --package-lock-only
+        working-directory: frontend
+      - run: (npm audit --json || true ) > audit.json
+        working-directory: frontend
+        name: Audit packages
+        env:
+          CI: true
+      - run: |
+          (echo -e "Key\tName\tSeverity\tIsDirect\tTitle\tURL\tCVSS_Score"; 
+          jq -r '
+          .vulnerabilities | 
+          to_entries[] | 
+          [
+            .key, 
+            .value.name, 
+            .value.severity, 
+            .value.isDirect, 
+            .value.via[0].title, 
+            .value.via[0].url, 
+            .value.via[0].cvss.score
+          ] | 
+          @tsv' audit.json) | column -t -s $'\t'
+        name: Audit results
+        working-directory: frontend
+
+  backend-integration:
+    runs-on: self-hosted
+    name: Backend Integration
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          architecture: "x64"
+          working-directory: backend
+          cache: "pip"
+      - name: Install backend modules
+        run: pip install -r requirements.txt
+        working-directory: backend
+      - name: install pip-audit
+        run: pip install pip-audit
+        working-directory: backend
+      - name: Audit results
+        run: pip-audit || true
+        working-directory: backend


### PR DESCRIPTION
Software composition analysis (SCA) is a practice in the fields of Information technology and software engineering for analyzing custom-built software applications to detect embedded open-source software and detect if they are up-to-date, contain security flaws
In RePan both frontend and backend use opensource libraries and packages: npm packages for the frontend and pip libraries for the backend. These libraries can contain vulnerabilities, this is why there is a need to audit these packages and identify the malicious ones and patch them.
The SCA will run in Github actions once a month, (the 1st day of each month at midnight) and will prompt the malicious packages, their severity and a description.

https://speedykom.atlassian.net/browse/REPAN-443


In this pull request, I added workflow file containing the jobs for auditing the frontend and backend libraries. 
This file has been tested in the branch : Feat/add-owasp-dependency-check 