### PR TITLE
fix jobs naming

### DIFF
--- a/.github/workflows/ci-cd-dev.yml
+++ b/.github/workflows/ci-cd-dev.yml
@@ -14,7 +14,7 @@ jobs:
   deploy-dev:
     name: Deploy
     runs-on: devserver
-    needs: [frontend-integration, backend-integration]
+    needs: [call-frontend-integration, call-backend-integration]
     steps:
       - uses: actions/checkout@v2
       - name: Connect to server and deploy

--- a/.github/workflows/ci-cd-prod.yml
+++ b/.github/workflows/ci-cd-prod.yml
@@ -14,7 +14,7 @@ jobs:
   deploy-prod:
     name: Deploy
     runs-on: devserver
-    needs: [frontend-integration, backend-integration]
+    needs: [call-frontend-integration, call-backend-integration]
     steps:
       - uses: actions/checkout@v2
       - name: Connect to server and deploy


### PR DESCRIPTION
Fixing the job names that the deployment job depends on:
frontend-integration -> call-frontend-integration 
backend-integration -> call-backend-integration