### PR TITLE
fix process chain pagination

### DIFF
--- a/frontend/src/modules/process/interface.ts
+++ b/frontend/src/modules/process/interface.ts
@@ -13,7 +13,7 @@ export interface DagDetails {
   data_source_name: string;
   start_date: any;
   schedule_interval: string;
-  status: string;
+  status: boolean;
   description: string;
   last_parsed_time: string;
   next_dagrun: string;

--- a/frontend/src/modules/process/views/list.tsx
+++ b/frontend/src/modules/process/views/list.tsx
@@ -40,12 +40,13 @@ export default function ProcessChainList() {
       processChainList?.dags?.length == 0
     )
       return null;
+
     var processChainToShowLength = 0;
     if (showDisabled) {
       processChainToShowLength = processChainList?.dags?.length;
     } else {
       processChainToShowLength = processChainList.dags.filter(
-        (dag) => dag.status === false
+        (dag) => dag.status == false
       ).length;
     }
 
@@ -84,8 +85,16 @@ export default function ProcessChainList() {
   };
 
   const renderProcessChainData = (processChainList: DagDetails[]) => {
+    var processChainToShow = null;
+    if (!showDisabled) {
+      processChainToShow = processChainList.filter(
+        (dag) => dag.status == false
+      );
+    } else {
+      processChainToShow = processChainList;
+    }
     if (!defaultPageSize && !!pipelineList) {
-      return processChainList.map((process) => {
+      return processChainToShow.map((process) => {
         return (
           <ProcessCard
             key={process.dag_id}
@@ -100,7 +109,7 @@ export default function ProcessChainList() {
     const startIndex = (currentPage - 1) * defaultPageSize;
     const endIndex = startIndex + defaultPageSize;
     if (!!pipelineList) {
-      return processChainList?.slice(startIndex, endIndex).map((process) => {
+      return processChainToShow?.slice(startIndex, endIndex).map((process) => {
         return (
           <ProcessCard
             key={process.dag_id}


### PR DESCRIPTION
![image](https://github.com/Speedykom/Regional-Pandemic-Analytics/assets/165824500/27331f02-b405-4b70-b38f-49c4fc798937)
The list of process chains this is showing only 3 process chain but it should show 5 (see bottom right Showing 1-5 of 11) and the others are shown on the second page.
The issue is with the number of active and inactive process chains being showed + issue with the pagination