### PR TITLE
Fix: pipeline validity check initial issue

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,5 +1,5 @@
 FROM apache/airflow:2.9.0
-RUN pip install airflow-hop-plugin
+RUN pip install airflow-hop-plugin==0.1.0b4
 RUN pip install python-jose
 RUN pip install Authlib
 RUN pip install python-keycloak==3.12.0 

--- a/backend/pipeline/rules/parquet_file_output_rule.py
+++ b/backend/pipeline/rules/parquet_file_output_rule.py
@@ -5,7 +5,7 @@ from .rule import Rule
 
 class ParquetFileOutputRule:
     rules = [
-        Rule("filename_base", "ftp://${minio_ftp}/parquets/${user_id}/${dag_id}", "InvalidFilenameBase"),
+        Rule("filename_base", "ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}", "InvalidFilenameBase"),
         Rule("filename_ext", "parquet", "InvalidFilenameExtension"),
         Rule("filename_include_copy", "N", "InvalidFilenameIncludeCopy"),
         Rule("filename_include_date", "N", "InvalidFilenameIncludeDate"),
@@ -17,20 +17,22 @@ class ParquetFileOutputRule:
     def __init__(self, xml_transform_element):
         self.xml_transform_element = xml_transform_element
 
+    def is_parquet_transform(self):
+        # First check if the XML transform element is a ParquetFileOutput element 
+        xml_transform_element_type = self.xml_transform_element.find("type")
+        return xml_transform_element_type is not None and xml_transform_element_type.text == "ParquetFileOutput"
+    
     def is_valid(self):
         valid_pipeline = False
         check_text = "MissingParquetTransform"
-        xml_transform_element_type = self.xml_transform_element.find("type")
 
-        # First check if the XML transform element is a ParquetFileOutput element 
-        if xml_transform_element_type is not None and xml_transform_element_type.text == "ParquetFileOutput":
-            for rule in self.rules:
-                element = self.xml_transform_element.find(rule.name)
-                if element is None or element.text != rule.value:
-                    valid_pipeline = False
-                    check_text = rule.error_text
-                    break
-            else:
-                valid_pipeline = True
-                check_text = "ValidPipeline"
+        for rule in self.rules:
+            element = self.xml_transform_element.find(rule.name)
+            if element is None or element.text != rule.value:
+                valid_pipeline = False
+                check_text = rule.error_text
+                break
+        else:
+            valid_pipeline = True
+            check_text = "ValidPipeline"
         return valid_pipeline, check_text

--- a/backend/pipeline/validator.py
+++ b/backend/pipeline/validator.py
@@ -13,10 +13,9 @@ def check_pipeline_validity(name):
     root = ET.fromstring(xml_data)
     for transform in root.iter("transform"):
         parquet_output_rule = ParquetFileOutputRule(transform)
-        valid_pipeline, check_text = parquet_output_rule.is_valid()
-        print("##########################")
-        print(valid_pipeline, check_text)
-        print("##########################")
+        # Ensure to run the validation only for ParquetFileOutput transforms
+        if(parquet_output_rule.is_parquet_transform()):
+            valid_pipeline, check_text = parquet_output_rule.is_valid()
         # New rules can be added here to check for other types of transforms
         ############################################
     return valid_pipeline, check_text


### PR DESCRIPTION
The pipeline validity check was always showing a pipeline which has more that one transform as no valid even it was a valid pipeline.
The root cause was that the check was run for all the transforms within a pipeline and this should only run for the parquet output transform.