### PR TITLE
Fix: Process Chain  Accordian Opens on Status Toggle 

### DIFF
--- a/frontend/src/modules/process/components/ProcessCard.tsx
+++ b/frontend/src/modules/process/components/ProcessCard.tsx
@@ -37,11 +37,15 @@ export default function ProcessCard({
   const dateProcess = new Date(process.start_date);
   const processName = punycode.toUnicode(process.dag_id);
 
-  const handleRunProcess = () => {
+  const handleRunProcess = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     runProcessById(process.dag_id);
   };
 
-  const handleToggleProcessStatus = () => {
+  const handleToggleProcessStatus = (
+    event: React.MouseEvent<HTMLButtonElement>
+  ) => {
+    event.stopPropagation();
     toggleProcessStatus(process.dag_id);
   };
 


### PR DESCRIPTION
Jira Ticket: https://speedykom.atlassian.net/browse/REPAN-458

Description
This PR addresses the UI issue of process chain accordian expanding when enabling-disabling process chain status

Changes Made
- Removed onClick handler from the Accordion component
- Updated onClick handlers for "Enable" and "Disable" buttons.

Testing Instructions
- Navigate to Process Chain section on the side bar
- if a process chain is disabled, click on enable, the accordian should not appear
- if a process chain is enabled, click on disable, the accordian should not appear