### PR TITLE
Fix: Missing pyClamd Library prevent user from login to the system

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -146,3 +146,4 @@ zipp==3.15.0
 python-keycloak==3.3.0
 python-jose==3.3.0
 punycode==0.2.1
+pyClamd==0.4.0


### PR DESCRIPTION
After merging the scan-uploaded-files #90 PR user dev server is no longer running and user cannot login to the system.
The backend shows that the pyClamd library is missing.
