### PR TITLE
Fix: Superset not starting because of missing python-jose library

### DIFF
--- a/superset/Dockerfile
+++ b/superset/Dockerfile
@@ -1,6 +1,6 @@
 FROM apache/superset:3.0.2
 
-RUN pip --no-cache-dir install Authlib  python-keycloak 'apache-superset[druid]' 'apache-superset[excel]' 'apache-superset[postgres]' 'apache-superset[prophet]' 'apache-superset[thumbnails]'
+RUN pip --no-cache-dir install Authlib  python-keycloak python-jose 'apache-superset[druid]' 'apache-superset[excel]' 'apache-superset[postgres]' 'apache-superset[prophet]' 'apache-superset[thumbnails]'
 
 USER root
 RUN apt update \


### PR DESCRIPTION
Issue observed on the production server, that superset is not starting.
