### PR TITLE
Fix process chain href in menu

### DIFF
--- a/frontend/src/common/components/Dashboard/Menu.tsx
+++ b/frontend/src/common/components/Dashboard/Menu.tsx
@@ -46,7 +46,7 @@ export const MenuData = [
     items: [
       {
         title: 'processChains',
-        href: 'process-chains',
+        href: '/process-chains',
         icon: BiGitPullRequest,
         scope: 'process:read',
       },


### PR DESCRIPTION
When clicking on process chain in left side menu, it should direct the use to the /process-chain however it just takes him to currentPage/process-chain
![image](https://github.com/user-attachments/assets/0eb40b02-fe22-4937-aa24-dbaae150e867)
