### PR TITLE
Improve pipeline execution and check_status message

### DIFF
--- a/airflow/include/templates/dag_template.jinja2
+++ b/airflow/include/templates/dag_template.jinja2
@@ -14,6 +14,8 @@ from requests.auth import HTTPBasicAuth
 from superset.superset_client import SupersetClient
 import urllib.parse
 from typing import Dict, Any
+import xml.etree.ElementTree as ET
+
 
 task_logger = logging.getLogger('airflow.task')
 
@@ -41,6 +43,20 @@ druid_auth = HTTPBasicAuth('admin', druid_admin_password)
 druid_coordinator_url = Variable.get('druid_coordinator_url')
 druid_router_url = Variable.get('druid_router_url')
 
+# This is a mandatory transformation to replace the parquet filename entered by the user with the correct one that can be processed by airflow
+def update_parquet_filename_in_content(xml_content, new_filename):
+    root = ET.fromstring(xml_content)
+    
+    for transform in root.findall("transform"):
+        transform_type = transform.find("type")
+        if transform_type is not None and transform_type.text == "ParquetFileOutput":
+            filename_base = transform.find("filename_base")
+            if filename_base is not None:
+                filename_base.text = new_filename
+    
+    updated_content = ET.tostring(root, encoding="unicode")
+    return updated_content
+
 # Download pipeline from minio bucket
 def download_pipeline_minio():
     task_logger.debug('Beginning download of pipeline from MinIO…')
@@ -53,6 +69,8 @@ def download_pipeline_minio():
         with open("/hop/config/projects/default/{{user_id}}/{{pipeline_display_name}}", 'r+') as file:
             content = file.read()
             updated_content = content.replace("${PROJECT_HOME}", "/files/")
+            # This is a mandatory transformation to replace the parquet filename entered by the user with the correct one that can be processed by airflow
+            updated_content = update_parquet_filename_in_content(updated_content, "ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}")
             file.seek(0)
             file.write(updated_content)
             file.truncate()

--- a/backend/pipeline/rules/parquet_file_output_rule.py
+++ b/backend/pipeline/rules/parquet_file_output_rule.py
@@ -5,7 +5,6 @@ from .rule import Rule
 
 class ParquetFileOutputRule:
     rules = [
-        Rule("filename_base", "ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}", "InvalidFilenameBase"),
         Rule("filename_ext", "parquet", "InvalidFilenameExtension"),
         Rule("filename_include_copy", "N", "InvalidFilenameIncludeCopy"),
         Rule("filename_include_date", "N", "InvalidFilenameIncludeDate"),
@@ -26,6 +25,9 @@ class ParquetFileOutputRule:
         valid_pipeline = False
         check_text = "MissingParquetTransform"
 
+        filename_base_element = self.xml_transform_element.find("filename_base")
+        if filename_base_element is None or not filename_base_element.text or not filename_base_element.text.strip():
+            return valid_pipeline, "InvalidFilenameBase"
         for rule in self.rules:
             element = self.xml_transform_element.find(rule.name)
             if element is None or element.text != rule.value:

--- a/frontend/src/common/locales/en.ts
+++ b/frontend/src/common/locales/en.ts
@@ -83,15 +83,19 @@ const enTranslation = {
   of: 'of',
   // Pipeline validation check
   MissingParquetTransform: 'One Parquet transform should be available',
-  InvalidFilenameBase:
-    'Filename base should be set to ftp://${minio_ftp}/parquets/${user_id}/${dag_id}',
-  InvalidFilenameExtension: 'Filename extension should be set to parquet',
-  InvalidFilenameIncludeCopy: 'Filename include copy should be set to N',
-  InvalidFilenameIncludeDate: 'Filename include date should be set to N',
+  InvalidFilenameBase: 'Parquet File Output: Filename base cannot be empty',
+  InvalidFilenameExtension:
+    'Parquet File Output: Extension should be set to parquet',
+  InvalidFilenameIncludeCopy:
+    'Parquet File Output: Include transform copy number should not be checked',
+  InvalidFilenameIncludeDate:
+    'Parquet File Output: Include date should not be checked',
   InvalidFilenameIncludeDatetime:
-    'Filename include datetime should be set to N',
-  InvalidFilenameIncludeSplit: 'Filename include split should be set to N',
-  InvalidFilenameIncludeTime: 'Filename include time should be set to N',
+    'Parquet File Output: Include date-time format should not be checked',
+  InvalidFilenameIncludeSplit:
+    'Parquet File Output:  Split into parts and include number should not be checked',
+  InvalidFilenameIncludeTime:
+    'Parquet File Output: Include time should not be checked',
   ValidPipeline: 'Pipeline is valid',
   pipelineInvalidName:
     'Invalid characters. Pipeline Name must consist exclusively of alphanumeric characters, dashes, dots and underscores.',

--- a/hop/pipelines/templates/Blank-Pipeline.hpl
+++ b/hop/pipelines/templates/Blank-Pipeline.hpl
@@ -64,7 +64,7 @@ specefic characters</note>
     <dictionary_page_size>1048576</dictionary_page_size>
     <fields>
 </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Cameroon-Workshop-Reading-Maternal-Death-DHIS2.hpl
+++ b/hop/pipelines/templates/Cameroon-Workshop-Reading-Maternal-Death-DHIS2.hpl
@@ -608,7 +608,7 @@ password: district</note>
         <target_field>Longitude</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/MINAS-Kobo-Pipeline-Json.hpl
+++ b/hop/pipelines/templates/MINAS-Kobo-Pipeline-Json.hpl
@@ -592,7 +592,7 @@ specefic characters</note>
         <target_field>start</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/MINAS-Kobo-Pipeline-excel.hpl
+++ b/hop/pipelines/templates/MINAS-Kobo-Pipeline-excel.hpl
@@ -487,7 +487,7 @@ specefic characters</note>
         <target_field>_index</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Multiple-IDSRs-DHIS2.hpl
+++ b/hop/pipelines/templates/Multiple-IDSRs-DHIS2.hpl
@@ -422,7 +422,7 @@ password: district</note>
         <target_field>OrgUnitLevel2Name</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Read-Covid-Data-From-Google-Sheet.hpl
+++ b/hop/pipelines/templates/Read-Covid-Data-From-Google-Sheet.hpl
@@ -539,7 +539,7 @@ specefic characters</note>
         <target_field>Longitude</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Read-Dengue-Fever-Data-From-Google-Sheet.hpl
+++ b/hop/pipelines/templates/Read-Dengue-Fever-Data-From-Google-Sheet.hpl
@@ -813,7 +813,7 @@ specefic characters</note>
         <target_field>AdministrativeLevelLongitude</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-API.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-API.hpl
@@ -326,7 +326,7 @@ specefic characters</note>
         <target_field>NewCases</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-CSV-File.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-CSV-File.hpl
@@ -289,7 +289,7 @@ specefic characters</note>
         <target_field>NewCases</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-Excel-File.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-Excel-File.hpl
@@ -289,7 +289,7 @@ specefic characters</note>
         <target_field>NewCases</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-FHIR-Server.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-FHIR-Server.hpl
@@ -270,7 +270,7 @@
         <target_field>Address</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-Json-File.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-Json-File.hpl
@@ -331,7 +331,7 @@ specefic characters</note>
         <target_field>NewCases</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Data-From-SORMAS.hpl
+++ b/hop/pipelines/templates/Reading-Data-From-SORMAS.hpl
@@ -324,7 +324,7 @@ specefic characters</note>
         <target_field>NewCases</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-IDSR-Malaria-DHIS2-With-Long-Lat.hpl
+++ b/hop/pipelines/templates/Reading-IDSR-Malaria-DHIS2-With-Long-Lat.hpl
@@ -452,7 +452,7 @@ password: district</note>
         <target_field>Longitude</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-IDSR-Malaria-DHIS2.hpl
+++ b/hop/pipelines/templates/Reading-IDSR-Malaria-DHIS2.hpl
@@ -443,7 +443,7 @@ password: district</note>
         <target_field>OrgUnitLevel2Name</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Morsures-Chien-DHIS2-LAST-12-Months-Cameroon.hpl
+++ b/hop/pipelines/templates/Reading-Morsures-Chien-DHIS2-LAST-12-Months-Cameroon.hpl
@@ -431,7 +431,7 @@ password: district</note>
         <target_field>OrgUnitLevel1Name</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/Reading-Organisation-Units-Level-2-DHIS2.hpl
+++ b/hop/pipelines/templates/Reading-Organisation-Units-Level-2-DHIS2.hpl
@@ -171,7 +171,7 @@ password: district</note>
         <target_field>OrgUnitLevel2Name</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>

--- a/hop/pipelines/templates/reading-data-from-data-grid.hpl
+++ b/hop/pipelines/templates/reading-data-from-data-grid.hpl
@@ -22929,7 +22929,7 @@ specefic characters</note>
         <target_field>deaths</target_field>
       </field>
     </fields>
-    <filename_base>ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}</filename_base>
+    <filename_base>filename</filename_base>
     <filename_create_parent_folders>Y</filename_create_parent_folders>
     <filename_datetime_format>yyyyMMdd-HHmmss</filename_datetime_format>
     <filename_ext>parquet</filename_ext>


### PR DESCRIPTION
New pipeline status_check failed texts added based on client feedback to make them more understandable

No need anymore to hardcode the parquet file output transform to "ftp://${minio_ftp}/parquets/${user_id}/${dag_display_name}"

This is preventing the user from executing the pipeline on the server as the minio server is not known there
