### PR TITLE
fix : auto update process chain list after process creation

### DIFF
--- a/frontend/src/modules/process/views/add.tsx
+++ b/frontend/src/modules/process/views/add.tsx
@@ -66,11 +66,16 @@ export const AddProcess = ({
           } as DagForm)
             .unwrap()
             .then(() => {
-              // WARNING !!!
-              // The only reason why we're using setTimeout
-              // is because Airflow takes time to rescan the dags directory
-              // NEED TO BE CHANGED !!!
-              setTimeout(refetch, 1000);
+              const intervalId = setInterval(() => {
+                refetch().then((response: any) => {
+                  const createdProcess = response.data?.dags.find(
+                    (dag: any) => dag.dag_id === encodedId
+                  );
+                  if (createdProcess) {
+                    clearInterval(intervalId);
+                  }
+                });
+              }, 500);
               toast.success(t('addProcess.successMessage'));
               closePanel();
             })


### PR DESCRIPTION
## Description
Newly created process chains are not directly visible in the list and a manual refresh is need. Repan should check periodically the dags directories and only refresh the process list when the new process is there. 

## Testing Instructions
- Create a new process chain.
- Wait till the Airflow rescans the dags directory.
- The new process chain should be displayed in the process list.