### PR TITLE
Update digital health officer role to restrict access to personal charts and dashboards

### DIFF
--- a/keycloak/realm/realm.json
+++ b/keycloak/realm/realm.json
@@ -103,7 +103,7 @@
         "composite": true,
         "composites": {
           "client": {
-            "superset": ["superset_admin"],
+            "superset": ["superset_gamma"],
             "airflow": ["airflow_admin"],
             "${BACKEND_CLIENT_ID}": ["dho_role", "admin"]
           }


### PR DESCRIPTION
# Description

This pull request modifies the default role for normal users from `superset_admin` to `superset_gamma`. This ensures that users can only view the charts and dashboards they have created, preventing access to those created by others.

## Changes

- [X] Updated user role from `superset_admin` to `superset_gamma` for dho users.  


## How to Test

1. Log in as a dho and create a chart or dashboard.  
2. Verify that the user can view only their own created content.  
3. Attempt to access charts or dashboards created by other users and confirm they are restricted.