### PR TITLE
Missing Certificate for Coordinator

### DIFF
--- a/gen-local-certs.sh
+++ b/gen-local-certs.sh
@@ -39,7 +39,7 @@ else
 fi
 
 #Our services
-service_table="frontend backend airflow druid keycloak minio console.minio guest.superset superset"
+service_table="frontend backend airflow druid coordinator keycloak minio console.minio guest.superset superset"
 #Geneate certificates for each service
 for service in $service_table; do
     commonname=$service


### PR DESCRIPTION
Coordinator didn't have a cert, it's the source of most errors I have been having since yesterday. Unfortunately, it's not always stated as the root cause in the logs in nginx, but in certain cases, it very well is, like this error below:

```
2025-07-01 11:00:35 /docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
2025-07-01 11:00:35 /docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
2025-07-01 11:00:35 /docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
2025-07-01 11:00:35 10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
2025-07-01 11:00:35 10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
2025-07-01 11:00:35 /docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
2025-07-01 11:00:35 /docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/airflow.conf.template to /etc/nginx/conf.d//package-conf/airflow.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/frontend.conf.template to /etc/nginx/conf.d//package-conf/frontend.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/keycloak.conf.template to /etc/nginx/conf.d//package-conf/keycloak.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/guest-superset.conf.template to /etc/nginx/conf.d//package-conf/guest-superset.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/storage.conf.template to /etc/nginx/conf.d//package-conf/storage.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/druid.conf.template to /etc/nginx/conf.d//package-conf/druid.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/backend.conf.template to /etc/nginx/conf.d//package-conf/backend.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/console.conf.template to /etc/nginx/conf.d//package-conf/console.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/coordinator.conf.template to /etc/nginx/conf.d//package-conf/coordinator.conf
2025-07-01 11:00:35 20-envsubst-on-templates.sh: Running envsubst on /etc/nginx/templates/package-conf/superset.conf.template to /etc/nginx/conf.d//package-conf/superset.conf
2025-07-01 11:00:35 /docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
2025-07-01 11:00:35 /docker-entrypoint.sh: Configuration complete; ready for start up
2025-07-01 11:00:35 2025/07/01 10:00:35 [emerg] 1#1: cannot load certificate "/etc/letsencrypt/live/coordinator.igad.local/fullchain.pem": BIO_new_file() failed (SSL: error:80000002:system library::No such file or directory:calling fopen(/etc/letsencrypt/live/coordinator.igad.local/fullchain.pem, r) error:10000080:BIO routines::no such file)
2025-07-01 11:00:35 nginx: [emerg] cannot load certificate "/etc/letsencrypt/live/coordinator.igad.local/fullchain.pem": BIO_new_file() failed (SSL: error:80000002:system library::No such file or directory:calling fopen(/etc/letsencrypt/live/coordinator.igad.local/fullchain.pem, r) error:10000080:BIO routines::no such file)
```

This line specifically: `cannot load certificate "/etc/letsencrypt/live/coordinator.igad.local/fullchain.pem"`

I hope this change fixes some of the issues others have been suffering from.