### PR TITLE
add trigger to the server monitoring

### DIFF
--- a/.github/workflows/trigger-server-monitoring.yml
+++ b/.github/workflows/trigger-server-monitoring.yml
@@ -1,0 +1,28 @@
+name: Trigger Server Monitoring
+
+on:
+  schedule:
+    - cron: "0 16 * * *"
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  trigger-monitoring:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workflow:
+          - propagation-monitoring.yml
+          - prod-monitoring.yml
+          - monitoring-env.yml
+    steps:
+      - name: Trigger ${{ matrix.workflow }}
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: ${{ matrix.workflow }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: "rel/repan-cameroon"
+          inputs: "{}"


### PR DESCRIPTION
Added a GitHub workflow to automatically trigger a checkup on the following three servers:

Production

Propagation

Monitoring

The checkup verifies that each URL is working and sends a report via email to the client.