### PR TITLE
Fix - Enable workflow_dispatch for monitoring workflows

### DIFF
--- a/.github/workflows/monitoring-env.yml
+++ b/.github/workflows/monitoring-env.yml
@@ -1,8 +1,7 @@
 name: Cameroon One Health Information System - Monitoring Environment
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
   env:
   # Email configuration
   BACKEND_MAIL_HOST: ${{ secrets.BACKEND_MAIL_HOST || 'smtp.gmail.com' }}

--- a/.github/workflows/prod-monitoring.yml
+++ b/.github/workflows/prod-monitoring.yml
@@ -1,8 +1,7 @@
 name: Cameroon One Health Information System - Production Monitoring
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
 
 env:
   # Email configuration

--- a/.github/workflows/propagation-monitoring.yml
+++ b/.github/workflows/propagation-monitoring.yml
@@ -1,8 +1,8 @@
 name: Cameroon One Health Information System - Propagation Monitoring
 
 on:
-  pull_request:
-    types: [opened, synchronize]
+  workflow_dispatch:
+  
 env:
   # Email configuration
   BACKEND_MAIL_HOST: ${{ secrets.BACKEND_MAIL_HOST || 'smtp.gmail.com' }}


### PR DESCRIPTION
The scheduled dispatcher workflow on main (Trigger Server Monitoring) requires the target workflows to accept workflow_dispatch events. Without this trigger, dispatch fails with an error. This change enables automated monitoring runs at the scheduled time (16:00 UTC) and still allows developers to trigger workflows manually when needed.